### PR TITLE
Use version glob for version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-jenkins_version: "1.586"
+jenkins_version: "1.*"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: An Ansible role for installing Jenkins.
   company: Azavea Inc.
   license: Apache
-  min_ansible_version: 1.2
+  min_ansible_version: 1.8
   platforms:
   - name: Ubuntu
     versions:


### PR DESCRIPTION
This change uses a glob for the minor version of the Jenkins package to be installed.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/azavea/ansible-jenkins/2)

<!-- Reviewable:end -->
