### PR TITLE
update dependency rolespec

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,9 +12,14 @@ galaxy_info:
   categories:
   - system
 dependencies:
-  - { role: "azavea.java", java_major_version: "7", java_version: "7u111*",
-      when:
-        "{{ ansible_distribution_version | version_compare('16.04','<') }}" }
-  - { role: "azavea.java", java_major_version: "8", java_version: "8u91*",
-      when:
-        "{{ ansible_distribution_version | version_compare('16.04','>=') }}" }
+  - src: "azavea.java"
+    java_major_version: "7"
+    java_version: "7u111*"
+    when:
+      "{{ ansible_distribution_version | version_compare('16.04','<') }}"
+
+  - src: "azavea.java"
+    java_major_version: "8"
+    java_version: "8u91*"
+    when:
+      "{{ ansible_distribution_version | version_compare('16.04','>=') }}"


### PR DESCRIPTION
Update role spec format so that a deprecation warning is no longer raised when installing through `ansible-galaxy`

See:
- https://github.com/ansible/ansible/pull/14612
- https://github.com/ansible/ansible/blob/85f4c958437f1ed10cdca93492d8f1b9ce7f6ddf/lib/ansible/playbook/role/requirement.py#L154

---

**Testing**

In another directory, create a `roles.yml` file that installs the role from this branch of the`ansible-jenkins` repository.

``` bash
$ cat roles.yml

- src: https://github.com/azavea/ansible-jenkins/archive/feature/tnation/rolespec.tar.gz
  name: azavea.jenkins
```

Then, install the role using `ansible-galaxy`.

``` bash
$ ansible-galaxy install -r roles.yml -p .        
- downloading role from https://github.com/azavea/ansible-jenkins/archive/feature/tnation/rolespec.tar.gz
- extracting azavea.jenkins to azavea.jenkins
- azavea.jenkins was installed successfully
- adding dependency: azavea.java
- dependency azavea.java already pending installation.
- downloading role 'java', owned by azavea
- downloading role from https://github.com/azavea/ansible-java/archive/0.4.0.tar.gz
- extracting azavea.java to azavea.java
- azavea.java was installed successfully
```
