### PR TITLE
Use less restrictive minor versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Tests are done using [molecule](http://molecule.readthedocs.io/). To run the tes
 ### Example 
 ```
 # Download molecule, dependencies
-$ pip install molecule
+$ pip install molecule==1.25 ansible==2.4.*
 
 # Change to the top-level project directory, which contains molecule.yml
 $ cd /path/to/ansible-jenkins

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,14 +12,4 @@ galaxy_info:
   categories:
   - system
 dependencies:
-  - src: "azavea.java"
-    java_major_version: "7"
-    java_version: "7u111*"
-    when:
-      "{{ ansible_distribution_version | version_compare('16.04','<') }}"
-
-  - src: "azavea.java"
-    java_major_version: "8"
-    java_version: "8u91*"
-    when:
-      "{{ ansible_distribution_version | version_compare('16.04','>=') }}"
+  - name: "azavea.java"

--- a/molecule.yml
+++ b/molecule.yml
@@ -1,9 +1,14 @@
 ---
 ansible:
   config_file: ansible.cfg
-  requirements_file: requirements.yml
   verbose:
-  sudo: True
+  become: True
+  host_vars:
+    ansible-jenkins-xenial64:
+      ansible_python_interpreter: /usr/bin/python3
+
+dependency:
+  requirements_file: requirements.yml
 
 vagrant:
   platforms:

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,32 +1,10 @@
 ---
 - hosts: all
-  gather_facts: False
   become: True
   pre_tasks:
-
-    # Check Ubuntu release version to determine if we need to install python 2,
-    # an Ansible dependency that isn't included by default in Ubuntu 16.04 and
-    # up.
-
-    - name: Check Ubuntu release
-      raw: cat /etc/lsb-release | grep DISTRIB_RELEASE | cut -d "=" -f2
-      register: ubuntu_release
-
-    - debug: msg="Running Ubuntu version {{ ubuntu_release.stdout|float }}"
-
-    # Update apt cache and install python 2 for Ubuntu versions greater than
-    # 16.04
-
     - name: Update APT cache
-      raw: apt-get update
-
-    - name: Install python
-      raw: apt-get install -yq python
-      when: "{{ ubuntu_release.stdout| version_compare('16.04', '>=') }}"
-
-    # Gather facts once ansible dependencies are installed
-    - name: Gather facts
-      setup:
+      apt: update_cache=yes
+      changed_when: False
 
   roles:
      - { role: "ansible-jenkins" }


### PR DESCRIPTION
# Overview

Whenever OpenJDK releases a new minor version, a previous one gets removed from their APT repository. If we try to install a Java version that is no longer available, it will cause failures that cascade upward to other roles that depend on `azavea.jenkins`. This PR unpins the minor version so that Ansible installs the latest release. 

## Changes
- Use looser minor version constraint in `meta/main.yml`
- Remove the dependency on `openjdk-7-jdk`, since Jenkins 2.5+ [requires Java 8](https://jenkins.io/blog/2017/04/10/jenkins-has-upgraded-to-java-8/) and OpenJDK 8 is [available](https://launchpad.net/~openjdk-r/+archive/ubuntu/ppa?field.series_filter=trusty) on Trusty. 
- Molecule config updates:
    - Update to version `1.25`.
    - On the `xenial64` test instance, set `ansible_python_interpeter` to `python3` instead of using `raw` to install python 2.

# Testing
- See http://gitlab.internal.azavea.com/hunchlab/azavea-hunchlab-web/merge_requests/1859
- Run `molecule test --platform=all`. Ensure all tests pass.

